### PR TITLE
[3.5] fix: remove the mandatory sequence of data binding for labelText and requiredText properties

### DIFF
--- a/ui-ngx/src/app/shared/components/entity/entity-autocomplete.component.ts
+++ b/ui-ngx/src/app/shared/components/entity/entity-autocomplete.component.ts
@@ -92,10 +92,18 @@ export class EntityAutocompleteComponent implements ControlValueAccessor, OnInit
   excludeEntityIds: Array<string>;
 
   @Input()
-  labelText: string;
+  set labelText(labelText: string) {
+    if (labelText && labelText.length) {
+      this.entityText = labelText;
+    }
+  }
 
   @Input()
-  requiredText: string;
+  set requiredText(requiredText: string) {
+    if (requiredText && requiredText.length) {
+      this.entityRequiredText = requiredText;
+    }
+  }
 
   @Input()
   appearance: MatFormFieldAppearance = 'legacy';
@@ -248,12 +256,6 @@ export class EntityAutocompleteComponent implements ControlValueAccessor, OnInit
           }
           break;
       }
-    }
-    if (this.labelText && this.labelText.length) {
-      this.entityText = this.labelText;
-    }
-    if (this.requiredText && this.requiredText.length) {
-      this.entityRequiredText = this.requiredText;
     }
     const currentEntity = this.getCurrentEntity();
     if (currentEntity) {


### PR DESCRIPTION
## Pull Request description

Fix: remove the mandatory sequence of data binding for `labelText` and `requiredText` properties

Example:
This sample code will not work because `requiredText` and `labelText` property are used after `entityType` property. So this pull request will remove this mandatory sequence.
```html
<tb-entity-autocomplete
    fxFlex
    [required]="required"
    (entityChanged)="entityLoaded($event)"
    [entityType]="EntityType.DEVICE "
    [requiredText]="requiredText"
    [labelText]="labelText"
    formControlName="entityId">
</tb-entity-autocomplete>
```